### PR TITLE
Add isort and flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,13 @@ redis = ">=3,<5"
 pytest = { version = "^6.2.5", optional = true }
 black = { version = "^21.9b0", optional = true }
 isort = {version = "^5.9.3", optional = true}
+flake8 = {version = "^4.0.1", optional = true}
+flake8-bugbear = {version = "^21.9.2", optional = true}
 
 [tool.poetry.extras]
-test = ["pytest", "black", "isort"]
-dev = ["pytest", "black", "isort"]
+test = ["pytest", "black", "isort", "flake8", "flake8-bugbear"]
+dev = ["pytest", "black", "isort", "flake8", "flake8-bugbear"]
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,11 @@ python = "^3.6.2"
 redis = ">=3,<5"
 pytest = { version = "^6.2.5", optional = true }
 black = { version = "^21.9b0", optional = true }
+isort = {version = "^5.9.3", optional = true}
 
 [tool.poetry.extras]
-test = ["pytest", "black"]
-dev = ["pytest", "black"]
+test = ["pytest", "black", "isort"]
+dev = ["pytest", "black", "isort"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -21,3 +22,6 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 addopts = "-v -ra"
 testpaths = "tests"
+
+[tool.isort]
+profile = "black"

--- a/redisconfig/config.py
+++ b/redisconfig/config.py
@@ -196,7 +196,7 @@ def config(url: Optional[str] = None) -> RedisConfig:
         url = url_from_env()
     config = from_url(url)
     if not config:
-        raise ValueError(f"Invalid Redis URL or missing environment variable")
+        raise ValueError("Invalid Redis URL or missing environment variable")
     return config
 
 

--- a/redisconfig/config.py
+++ b/redisconfig/config.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass, replace
 from typing import Optional
-from urllib.parse import urlparse, urlunparse, parse_qs
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 from redis import Redis
 from typing_extensions import Final, TypedDict

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,17 @@
+@@ -1,3 +1,12 @@
 [mypy]
 files = redisconfig
 ignore_missing_imports = true
+
+[flake8]
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,W503,W504,E501
+exclude =
+    .git,
+    __pycache__,
+    .eggs,
+    build,
+    dist,
+    .tox,
+    .venv

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 import os
 from unittest import mock
-from urllib.parse import urlparse
 
 import pytest
 from redis.connection import SSLConnection
@@ -101,7 +100,7 @@ def test_env_config():
 
 def test_config_no_url_error():
     with pytest.raises(ValueError):
-        config = redisconfig.config()
+        redisconfig.config()
 
 
 @mock.patch.dict(os.environ, {DEFAULT_ENV_VAR: "rediss:///5"})


### PR DESCRIPTION
This introduces:

* flake8 for linting, configured for Black compatibility, and fixes up a few issues it surfaced.
* isort for import sorting, configured for Black compatibility. Black + isort make a good combination because it means the entirety of the codebase can be auto-formatted to avoid any drama over code style.